### PR TITLE
Clean Up rse_feebas_sid_finder

### DIFF
--- a/RSE_Trendy_Saying_2_SID/RSE_Feebas_SID_Finder.py
+++ b/RSE_Trendy_Saying_2_SID/RSE_Feebas_SID_Finder.py
@@ -1,172 +1,192 @@
-# Majority of this done by Shao. I (Lappy) just made it look pretty, added user inputs, and made an infographic.
-# Infographic: https://github.com/HappyLappy1/Lappy-Python-Scripts/blob/main/RSE_Trendy_Saying_2_SID/RSE_Feebas_Tiles_Index.png
-def advance(seed):
-    return (0x41C64E6D * seed + 0x00006073) & 0xFFFFFFFF
+# Majority of this done by Shao.
+# I (Lappy) just made it look pretty, added user inputs, and made an infographic.
+# Infographic:
+# https://github.com/HappyLappy1/Lappy-Python-Scripts/blob/main/RSE_Trendy_Saying_2_SID/RSE_Feebas_Tiles_Index.png
+class PokeRNG:
+    """Standard LCRNG used in RSE"""
 
-def prev(seed):
-    return (seed*0xeeb9eb65+0xa3561a1)& 0xFFFFFFFF
+    add = 0x6073
+    mult = 0x41C64E6D
 
-def iso_2(seed):
-    return (1103515245 * (seed) + 12345) & 0xFFFFFFFF
+    def __init__(self, seed: int) -> None:
+        self.seed: int = seed & 0xFFFFFFFF
+        self.prev_mult: int = pow(self.mult, -1, 2**32)
+        self.prev_add: int = (self.add * self.prev_mult) & 0xFFFFFFFF
 
-class NewGameRNG:
-    def __init__(self, seed):
-        self.seed = seed
-        self.trends = []
-        self.populate_trends()
-        self.feebas_seed = self.trends[0][2]
-        
-    def random(self):
-        self.seed = (0x41C64E6D * self.seed + 0x00006073) & 0xFFFFFFFF
-        return self.seed >> 16
-    
-    def should_swap(self, a, b):
-        if a[0] > b[0]:
-            return True
-        elif a[0] < b[0]:
-            return False
-        elif a[1] > b[1]:
-            return True
-        elif a[1] < b[1]:
-            return False
+    def next(self) -> int:
+        """Advance the LCRNG and return the next seed"""
+        self.seed = (self.seed * self.mult + self.add) & 0xFFFFFFFF
+        return self.seed
+
+    def prev(self) -> int:
+        """Advance the LCRNG backwards and return the previous seed"""
+        self.seed = (self.seed * self.prev_mult + self.prev_add) & 0xFFFFFFFF
+        return self.seed
+
+    def advance(self, adv: int) -> None:
+        """Advance the LCRNG in either direction"""
+        if adv >= 0:
+            for _ in range(adv):
+                self.next()
         else:
-            return self.random() & 1
-        
-    def populate_trends(self):
-        self.trends = []
-        for i in range(5):
-            self.random() # Call to generate first word, no impact
-            self.random() # Call to decide which group second word comes from, no impact
-            self.random() # Call to generate second group, no impact
-            g = self.random() & 1 # Call to decide whether trend is gaining trendiness, no impact
-            # Enter SeedTrendRNG
-            rand = self.random() % 98
-            if rand > 50:
-                rand = self.random() % 98
-                if rand > 80:
-                    rand = self.random() % 98
-            maxtrend = rand+30
-            trend = ((self.random()) % (rand+1)) + 30
-            rand = self.random()
-            self.trends.append((trend, maxtrend, rand, g))
-        # Now need to sort the trends
-        for i in range(5):
-            for j in range(i+1, 5):
-                if (self.should_swap(self.trends[j], self.trends[i])):
-                    temp = self.trends[i]
-                    self.trends[i] = self.trends[j]
-                    self.trends[j] = temp
-            
-def Feebas_Spots(seed):
-    spots = []
-    i=0
-    while i < 6:
-        seed = iso_2(seed)
-        rand = (seed >> 16) % 447
-        if rand == 0:
-            rand == 447
-        if rand >= 4:
-            spots.append(rand)
-            i+=1
+            for _ in range(-adv):
+                self.prev()
+
+    def next_u16(self) -> int:
+        """Advance the LCRNG and return the next 16-bit high"""
+        return self.next() >> 16
+
+    def prev_u16(self) -> int:
+        """Advance the LCRNG backwards and return the previous 16-bit high"""
+        return self.prev() >> 16
+
+    def next_rand(self, maximum: int) -> int:
+        """Advance the LCRNG and return the next rand [0, maximum)"""
+        return self.next_u16() % maximum
+
+    def prev_rand(self, maximum: int) -> int:
+        """Advance the LCRNG backwards return the previous rand [0, maximum)"""
+        return self.prev_u16() % maximum
+
+
+class MRNG(PokeRNG):
+    """Secondary RNG used in RSE"""
+
+    add = 0x3039
+
+
+def generate_feebas_seed(seed: int) -> int:
+    """Generate feebas seed from rng state"""
+    rng = PokeRNG(seed)
+    trends = []
+    for _ in range(5):
+        rng.advance(4)
+        rand = rng.next_rand(98)
+        if rand > 50:
+            rand = rng.next_rand(98)
+            if rand > 80:
+                rand = rng.next_rand(98)
+        max_trend = rand + 30
+        trend = rng.next_rand(rand + 1) + 30
+        rand = rng.next_u16()
+        trends.append(((trend, max_trend), rand))
+    feebas_trend = trends.pop(0)
+    # only need to sort the first index
+    for trend in trends:
+        if (trend[0] > feebas_trend[0]) or (
+            trend[0] == feebas_trend[0] and rng.next_rand(2)
+        ):
+            feebas_trend = trend
+    return feebas_trend[1]
+
+
+def generate_feebas_spots(seed: int):
+    """Generate feebas spots from feebas seed"""
+    spots = set()
+    rng = MRNG(seed)
+    # generate 6 spots
+    while len(spots) < 6:
+        spot = rng.next_rand(447)
+        if spot == 0:
+            spot = 447
+        # inaccessible tiles that are skipped over
+        if spot >= 4:
+            spots.add(spot)
     return spots
-            
-def EmeraldSearch(TID, feebas_seed, min_advances, max_advances):          
-    init_seed = TID
-    advances = 0
-    while (advances < min_advances):
-        init_seed = advance(init_seed)
-        advances+=1
-    while(advances <= max_advances):
-        trends = NewGameRNG(init_seed)
-        if trends.feebas_seed == feebas_seed:
-            two = prev(prev(init_seed))
-            three = prev(two)
-            SIDtwo = two >> 16
-            SIDthree = three >> 16
-            print(f"SID: {SIDtwo} matches your feebas seed on advance {advances-3} with 2 Vblanks") 
-            print(f"SID: {SIDthree} matches your feebas seed on advance {advances-4} with 3 Vblanks")
-        advances+=1
-        init_seed = advance(init_seed)
 
-def RSSearch(TID, feebas_seed, min_advances, max_advances, game_seed = 0x5A0):
-    init_seed = game_seed
-    advances = 0
-    while (advances < min_advances):
-        init_seed = advance(init_seed)
-        advances+=1
-    while (advances <= max_advances):
-        if TID == (init_seed >> 16):
-            dewford_seed = advance(advance(init_seed))
-            if NewGameRNG(dewford_seed).feebas_seed == feebas_seed:
-                SID = prev(init_seed) >> 16
-                print(f"SID: {SID} matches your feebas seed on advance {advances-2} with 2 Vblanks")
-            dewford_seed = advance(dewford_seed)
-            if NewGameRNG(dewford_seed).feebas_seed == feebas_seed:
-                SID = prev(init_seed) >> 16
-                print(f"SID: {SID} matches your feebas seed on advance {advances-3}")
-        advances+=1
-        init_seed = advance(init_seed)        
 
-    
-def Emerald_SID_From_Spots(TID, spots, min_advances, max_advances):
-    printed_anything = False
-    init_seed = TID
-    advances = 0
-    while (advances < min_advances):
-        init_seed = advance(init_seed)
-        advances+=1
-    while(advances <= max_advances):
-        feebas_spots = Feebas_Spots(NewGameRNG(init_seed).feebas_seed)
-        if all(spot in feebas_spots for spot in spots):
-            two = prev(prev(init_seed))
-            three = prev(two)
-            SIDtwo = two >> 16
-            SIDthree = three >> 16
-            print(f"SID: {SIDtwo} matches your feebas seed on advance {advances-3} with 2 Vblanks and spots {feebas_spots}") 
-            print(f"SID: {SIDthree} matches your feebas seed on advance {advances-4} with 3 Vblanks and spots {feebas_spots}")
-            printed_anything = True
-        advances+=1
-        init_seed = advance(init_seed)
-    if not printed_anything:
+def emerald_sid_from_spots(
+    tid: int, known_spots: set, min_advances: int, max_advances: int
+):
+    """Search for Emerald SID based on known feebas spots"""
+    rng = PokeRNG(tid)
+    rng.advance(min_advances)
+    results_found = False
+    for advance in range(min_advances, max_advances):
+        go = PokeRNG(rng.seed)
+        sid_3 = go.next_u16()
+        sid_2 = go.next_u16()
+        go.advance(2)  # 2 vblanks
+        test_spots = generate_feebas_spots(generate_feebas_seed(go.seed))
+        if all(known_spot in test_spots for known_spot in known_spots):
+            print(
+                f"SID: {sid_3} matches your feebas seed "
+                f"on advance {advance} with 3 Vblanks and spots {test_spots}"
+            )
+            print(
+                f"SID: {sid_2} matches your feebas seed "
+                f"on advance {advance + 1} with 2 Vblanks and spots {test_spots}"
+            )
+            results_found = True
+        rng.next()
+
+    if not results_found:
         print("No Results found!")
-        
-def RS_SID_From_Spots(TID, spots, min_advances, max_advances, game_seed = 0x5A0):
-    printed_anything = False
-    init_seed = game_seed
-    advances = 0
-    while (advances < min_advances):
-        init_seed = advance(init_seed)
-        advances+=1
-    while (advances <= max_advances):
-        if TID == (init_seed >> 16):
-            dewford_seed = advance(advance(init_seed))
-            feebas_spots = Feebas_Spots(NewGameRNG(dewford_seed).feebas_seed)
-            if all(spot in feebas_spots for spot in spots):
-                SID = prev(init_seed) >> 16
-                print(f"SID: {SID} is consistent on advance {advances-2} with 2 Vblanks and spots {feebas_spots}")
-                printed_anything = True
-            dewford_seed = advance(dewford_seed)
-            feebas_spots = Feebas_Spots(NewGameRNG(dewford_seed).feebas_seed)
-            if all(spot in feebas_spots for spot in spots):
-                SID = prev(init_seed) >> 16
-                print(f"SID: {SID} matches your feebas seed on advance {advances-3} with 3 Vblanks and spots {feebas_spots}")
-                printed_anything = True
-        advances+=1
-        init_seed = advance(init_seed)
-    if not printed_anything:
+
+
+def rs_sid_from_spots(
+    tid: int,
+    known_spots: set,
+    min_advances: int,
+    max_advances: int,
+):
+    """Search for Ruby/Sapphire SID based on known feebas spots"""
+    rng = PokeRNG(0x5A0)
+    rng.advance(min_advances)
+    results_found = False
+    for advance in range(min_advances, max_advances):
+        go = PokeRNG(rng.seed)
+        sid = go.next_u16()
+        if tid == go.next_u16():
+            go.next()
+            test_spots = generate_feebas_spots(generate_feebas_seed(go.next()))
+            if all(spot in test_spots for spot in known_spots):
+                print(
+                    f"SID: {sid} is consistent on "
+                    f"advance {advance} with 2 Vblanks and spots {test_spots}"
+                )
+                results_found = True
+            test_spots = generate_feebas_spots(generate_feebas_seed(go.next()))
+            if all(spot in test_spots for spot in known_spots):
+                print(
+                    f"SID: {sid} matches your feebas seed "
+                    f"on advance {advance - 3} with 3 Vblanks and spots {test_spots}"
+                )
+                results_found = True
+        rng.next()
+    if not results_found:
         print("No Results found!")
-        
-print("Tiles 1, 2, and 3 are inaccesible water tiles. However, the game intentionally rerolls them if they are ever selected.")
-print("Tiles 105, 119, 132 and 144 are land tiles the player cannot fish on. The game can generate feebas on these tiles")
-print("Tiles 296, 297 and 298 are inaccessible water tiles that can contain feebas. The game can generate feebas on these tiles.")
+
+
+print(
+    "Tiles 1, 2, and 3 are inaccesible water tiles. "
+    "However, the game intentionally rerolls them if they are ever selected."
+)
+print(
+    "Tiles 105, 119, 132 and 144 are land tiles the player cannot fish on. "
+    "The game can generate feebas on these tiles"
+)
+print(
+    "Tiles 296, 297 and 298 are inaccessible water tiles that can contain feebas. "
+    "The game can generate feebas on these tiles."
+)
 
 tid = int(input("Trainer ID: "))
-feebas_tiles = input("Known Feebas Tile Indices Separated by Commas (See infographic for conversion): ").split(",")
+feebas_tiles = {
+    int(tile.strip())
+    for tile in input(
+        "Known Feebas Tile Indices Separated by Commas (See infographic for conversion): "
+    ).split(",")
+}
 min_advances = int(input("Minimum Advances: "))
 max_advances = int(input("Maximum Advances: "))
-for i in range(len(feebas_tiles)):
-    feebas_tiles[i] = int(feebas_tiles[i].strip())
-if input("Which Game Version are you attempting to find the Secret ID of? Emerald = 1, Ruby/Sapphire = 0") == "1":
-    Emerald_SID_From_Spots(tid, feebas_tiles, min_advances, max_advances)
+if (
+    input(
+        "Which Game Version are you attempting to find the Secret ID of? "
+        "Emerald = 1, Ruby/Sapphire = 0: "
+    )
+    == "1"
+):
+    emerald_sid_from_spots(tid, feebas_tiles, min_advances, max_advances)
 else:
-    RS_SID_From_Spots(tid, feebas_tiles, min_advances, max_advances)
+    rs_sid_from_spots(tid, feebas_tiles, min_advances, max_advances)


### PR DESCRIPTION
This PR cleans up some of the logic and formatting in rse_feebas_sid_finder.py.

Main changes are:
- Use a class for PokeRNG/MRNG w/ methods for advancing and modulo rand generation
- Turn NewGameRNG into generate_feebas_seed because nothing about it really needs to be a class if feebas is the only concern
- Don't store ``g`` in the trend tuples because it's irrelevant
- Compare trend tuples directly instead of accessing each index to compare
- Only sort the first trend because that's the only one that matters for feebas
- Remove unused EmeraldSearch and RSSearch
- Fix name case to be camel_case
- Fix lines to be <= 100 characters
- Formatting with black
- Type hints
- General restructuring of logic to be more pythonic

I would've also renamed RSE_Feebas_SID_Finder to be lowercase but that doesn't seem to be detected by git.

I've tested this with Shao's original examples but I'm not 100% sure I haven't broke anything so check before merging.